### PR TITLE
Simplify tab title

### DIFF
--- a/src/commands/export-into-multiple-notes-remote/index.ts
+++ b/src/commands/export-into-multiple-notes-remote/index.ts
@@ -1,11 +1,11 @@
 import { App, Command, Notice } from "obsidian";
 import { createFileByParts, createFolder } from "src/utils/file-utils";
 import { generateFrontmatter } from "src/utils/frontmatter-utils";
-import { appendWebsiteTitle, getWebsiteTitle, removeNotificationCount, removeTrailingHyphen, removeTrailingPeriod, removeWebsiteTitles, trimForObsidian } from "src/utils/title-utils";
+import { removeNotificationCount, trimForFileSystem } from "src/utils/title-utils";
 import { PluginSettings } from "src/types";
 import { pipeline } from "src/utils/pipeline";
 import { formatForFileSystem } from "src/utils/file-system-utils";
-import { decodeHtmlEntities, toSentenceCase } from "src/utils/string-utils";
+import { decodeHtmlEntities } from "src/utils/string-utils";
 import { doesUrlExist } from "src/utils/vault";
 import { exportRemoteTabs } from "src/export/remote-export";
 
@@ -59,21 +59,15 @@ const callback = (app: App, settings: PluginSettings) => async () => {
 				continue;
 			}
 
-			const titlePipeline = pipeline(decodeHtmlEntities, formatForFileSystem, removeWebsiteTitles, removeTrailingHyphen, removeTrailingPeriod, removeNotificationCount);
-			const titleString = (titlePipeline(title) as string).trim();
-
-			const websiteTitle = getWebsiteTitle(url);
-			const trimmed = trimForObsidian(titleString as string, websiteTitle, "md");
-
-			const sentenceCase = toSentenceCase(trimmed);
-			const titleWithWebsite = appendWebsiteTitle(sentenceCase, websiteTitle);
-
+			const titlePipeline = pipeline(decodeHtmlEntities, formatForFileSystem, removeNotificationCount);
+			const formattedTitle = titlePipeline(title) as string;
+			const trimmedTitle = trimForFileSystem(formattedTitle, ".md");
 			const data = generateFrontmatter(urlFrontmatterKey, url);
 
 			const result = await createFileByParts(
 				app,
 				vaultSavePath,
-				titleWithWebsite,
+				trimmedTitle,
 				"md",
 				data
 			);

--- a/src/commands/export-into-multiple-notes/README.md
+++ b/src/commands/export-into-multiple-notes/README.md
@@ -9,15 +9,10 @@ flowchart TD
 	subgraph one[for each tab]
 	C{Check if url already exists} --> D{Check if excluded}
 	D --> E[Remove invalid characters for file system]
-	E --> F[Remove website title]
-	F --> G[Remove trailing hyphen]
-	G --> H[Remove trailing period]
-	H --> I["Remove notification count '(1)'"]
-	I --> J[Trim up 150 characters]
-	J --> K[Convert to sentence case]
-	K --> L[Append website title in parenthesis]
-	L --> M[Get frontmatter for file]
-	M --> N[Create file with frontmatter data]
+	E --> F["Remove notification count '(1)'"]
+	F --> G[Trim to 255 characters]
+	G --> H[Get frontmatter for file]
+	H --> I[Create file with frontmatter data]
 
 	end
 	N --> O[Push success notification]

--- a/src/commands/export-into-multiple-notes/index.ts
+++ b/src/commands/export-into-multiple-notes/index.ts
@@ -1,11 +1,10 @@
 import { App, Command, Notice } from "obsidian";
 import { createFile, createFolder } from "src/utils/file-utils";
 import { generateFrontmatter } from "src/utils/frontmatter-utils";
-import { appendWebsiteTitle, getWebsiteTitle, removeNotificationCount, removeTrailingHyphen, removeTrailingPeriod, removeWebsiteTitles, trimForObsidian } from "src/utils/title-utils";
+import { removeNotificationCount, trimForFileSystem } from "src/utils/title-utils";
 import { PluginSettings } from "src/types";
 import { pipeline } from "src/utils/pipeline";
 import { formatForFileSystem } from "src/utils/file-system-utils";
-import { toSentenceCase } from "src/utils/string-utils";
 import { doesUrlExist } from "src/utils/vault";
 import { exportLocalTabs } from "src/export/local-export";
 
@@ -34,7 +33,6 @@ const callback = (app: App, settings: PluginSettings) => async () => {
 		for (const tab of tabs) {
 			const { title, url } = tab;
 
-
 			if (excludedLinks.find(link => {
 				return url.includes(link)
 			})) {
@@ -47,17 +45,12 @@ const callback = (app: App, settings: PluginSettings) => async () => {
 				continue;
 			}
 
-			const titlePipeline = pipeline(formatForFileSystem, removeWebsiteTitles, removeTrailingHyphen, removeTrailingPeriod, removeNotificationCount);
-			const titleString = (titlePipeline(title) as string).trim();
+			//Hnadle empty title
+			const titlePipeline = pipeline(formatForFileSystem, removeNotificationCount);
+			const formattedTitle = titlePipeline(title) as string;
+			const trimmedTitle = trimForFileSystem(formattedTitle, ".md");
 
-			const websiteTitle = getWebsiteTitle(url);
-			const trimmed = trimForObsidian(titleString as string, websiteTitle, "md");
-
-			const sentenceCase = toSentenceCase(trimmed);
-			const titleWithWebsite = appendWebsiteTitle(sentenceCase, websiteTitle);
-
-			const fileName = `${titleWithWebsite}.md`;
-
+			const fileName = `${trimmedTitle}.md`;
 			const filePath = `${vaultSavePath}/${fileName}`;
 			const data = generateFrontmatter(urlFrontmatterKey, url);
 

--- a/src/commands/export-into-multiple-notes/index.ts
+++ b/src/commands/export-into-multiple-notes/index.ts
@@ -33,9 +33,9 @@ const callback = (app: App, settings: PluginSettings) => async () => {
 		for (const tab of tabs) {
 			const { title, url } = tab;
 
-			if (excludedLinks.find(link => {
-				return url.includes(link)
-			})) {
+			if (excludedLinks.find(link =>
+				url.includes(link)
+			)) {
 				console.log(`URL is excluded: ${url}`);
 				continue;
 			}

--- a/src/commands/export-into-single-note/index.ts
+++ b/src/commands/export-into-single-note/index.ts
@@ -29,6 +29,7 @@ const callback = (app: App, settings: PluginSettings) => async () => {
 		new Notice(
 			`Exported ${tabs.length} browser tabs from ${localBrowserAppName}`
 		);
+		console.log(`Exported ${tabs.length} browser tabs from ${localBrowserAppName}`);
 	} catch (err) {
 		console.error(err);
 		new Notice(`Error exporting browser tabs: ${err.message}`);

--- a/src/commands/export-into-single-note/index.ts
+++ b/src/commands/export-into-single-note/index.ts
@@ -18,6 +18,7 @@ const callback = (app: App, settings: PluginSettings) => async () => {
 		const tabs = await exportLocalTabs(
 			localBrowserAppName
 		);
+
 		const markdownLinks = tabs.map((tab) => `[${tab.title}](${tab.url})`);
 
 		const filePath = `${vaultSavePath}/${fileName} ${Date.now()}.md`;

--- a/src/commands/export-into-single-note/index.ts
+++ b/src/commands/export-into-single-note/index.ts
@@ -12,14 +12,20 @@ export const exportIntoSingleNoteCommand = (app: App, settings: PluginSettings):
 };
 
 const callback = (app: App, settings: PluginSettings) => async () => {
-	const { vaultSavePath, localBrowserAppName, fileName } = settings;
+	const { vaultSavePath, localBrowserAppName, fileName, exportTitleAndUrl } = settings;
 	try {
 		await createFolder(app, vaultSavePath);
 		const tabs = await exportLocalTabs(
 			localBrowserAppName
 		);
 
-		const markdownLinks = tabs.map((tab) => `[${tab.title}](${tab.url})`);
+		const markdownLinks = tabs.map((tab) => {
+			const { title, url } = tab;
+			if (exportTitleAndUrl) {
+				return `[${title}](${url})`;
+			}
+			return url;
+		});
 
 		const filePath = `${vaultSavePath}/${fileName} ${Date.now()}.md`;
 		await createFile(

--- a/src/commands/export-into-single-note/index.ts
+++ b/src/commands/export-into-single-note/index.ts
@@ -12,14 +12,24 @@ export const exportIntoSingleNoteCommand = (app: App, settings: PluginSettings):
 };
 
 const callback = (app: App, settings: PluginSettings) => async () => {
-	const { vaultSavePath, localBrowserAppName, fileName, exportTitleAndUrl } = settings;
+	const { vaultSavePath, localBrowserAppName, fileName, exportTitleAndUrl, excludedLinks } = settings;
 	try {
 		await createFolder(app, vaultSavePath);
 		const tabs = await exportLocalTabs(
 			localBrowserAppName
 		);
 
-		const markdownLinks = tabs.map((tab) => {
+		const filteredTabs = tabs.filter((tab) => {
+			const { url } = tab;
+			if (excludedLinks.find(link =>
+				url.includes(link)
+			)) {
+				return false;
+			}
+			return true;
+		});
+
+		const markdownLinks = filteredTabs.map((tab) => {
 			const { title, url } = tab;
 			if (exportTitleAndUrl) {
 				return `[${title}](${url})`;

--- a/src/export/local-export.ts
+++ b/src/export/local-export.ts
@@ -1,6 +1,7 @@
 import { exec as execCallback } from "child_process";
 import { promisify } from "util";
 import { BrowserTab } from "./types";
+import { getEmptyTabTitle } from "src/utils/title-utils";
 
 const exec = promisify(execCallback);
 
@@ -50,9 +51,9 @@ export const exportLocalTabs = async (browserApplicationName: string): Promise<B
 				let title = titleParts.join("|"); // Rejoin the title in case it contains "|"
 
 				//It's possible that the title is empty if the tab has not loaded yet
-				if (title.trim() === "") {
-					title = `Untitled tab ${crypto.randomUUID()}`;
-				}
+				if (title.trim() === "")
+					title = getEmptyTabTitle();
+
 				return { url, title };
 			});
 		return tabs;

--- a/src/export/local-export.ts
+++ b/src/export/local-export.ts
@@ -2,6 +2,7 @@ import { exec as execCallback } from "child_process";
 import { promisify } from "util";
 import { BrowserTab } from "./types";
 import { getEmptyTabTitle } from "src/utils/title-utils";
+import { filterDuplicateTabs } from "./utils";
 
 const exec = promisify(execCallback);
 
@@ -56,7 +57,8 @@ export const exportLocalTabs = async (browserApplicationName: string): Promise<B
 
 				return { url, title };
 			});
-		return tabs;
+		const filteredTabs = filterDuplicateTabs(tabs);
+		return filteredTabs;
 	} catch (err) {
 		throw err;
 	}

--- a/src/export/local-export.ts
+++ b/src/export/local-export.ts
@@ -47,7 +47,12 @@ export const exportLocalTabs = async (browserApplicationName: string): Promise<B
 			.map((entry) => {
 				// Split the entry by the first occurrence of "|"
 				const [url, ...titleParts] = entry.split("|");
-				const title = titleParts.join("|"); // Rejoin the title in case it contains "|"
+				let title = titleParts.join("|"); // Rejoin the title in case it contains "|"
+
+				//It's possible that the title is empty if the tab has not loaded yet
+				if (title.trim() === "") {
+					title = `Untitled tab ${crypto.randomUUID()}`;
+				}
 				return { url, title };
 			});
 		return tabs;

--- a/src/export/remote-export.ts
+++ b/src/export/remote-export.ts
@@ -1,6 +1,7 @@
 import { exec as execCallback } from "child_process";
 import { promisify } from "util";
 import { BrowserTab } from "./types";
+import { getEmptyTabTitle } from "src/utils/title-utils";
 
 const exec = promisify(execCallback);
 
@@ -40,12 +41,17 @@ export const exportRemoteTabs = async (browserApplicationName: string, adbPath: 
 
 		const arr = JSON.parse(stdout);
 		const tabs: BrowserTab[] = arr.map((entry: unknown) => {
-			const { url, title } = entry as {
+			const { url, title: originalTitle } = entry as {
 				title: string, url: string
 			}
+
+			let title = originalTitle;
+			//It's possible that the title is empty if the tab has not loaded yet
+			if (title.trim() === "")
+				title = getEmptyTabTitle();
 			return {
-				url,
-				title
+				title,
+				url
 			}
 		});
 		return tabs;

--- a/src/export/remote-export.ts
+++ b/src/export/remote-export.ts
@@ -2,6 +2,7 @@ import { exec as execCallback } from "child_process";
 import { promisify } from "util";
 import { BrowserTab } from "./types";
 import { getEmptyTabTitle } from "src/utils/title-utils";
+import { filterDuplicateTabs } from "./utils";
 
 const exec = promisify(execCallback);
 
@@ -54,7 +55,8 @@ export const exportRemoteTabs = async (browserApplicationName: string, adbPath: 
 				url
 			}
 		});
-		return tabs;
+		const filteredTabs = filterDuplicateTabs(tabs);
+		return filteredTabs;
 	} catch (err: unknown) {
 		const error = err as Error;
 		if (error.message.includes("no devices/emulators found")) {

--- a/src/export/utils.ts
+++ b/src/export/utils.ts
@@ -1,0 +1,13 @@
+import { BrowserTab } from "./types";
+
+export const filterDuplicateTabs = (tabs: BrowserTab[]): BrowserTab[] => {
+	const urls: string[] = [];
+	return tabs.filter((tab) => {
+		const { url } = tab;
+		if (urls.includes(url)) {
+			return false;
+		}
+		urls.push(url);
+		return true;
+	});
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,7 +16,7 @@ const DEFAULT_SETTINGS: PluginSettings = {
 	remoteBrowserAppName: "",
 	fileName: "Browser tabs",
 	urlFrontmatterKey: "url",
-	appendWebsiteType: false,
+	exportTitleAndUrl: true,
 	excludedLinks: [],
 	adbPath: "",
 };

--- a/src/obsidian/settings-tab.ts
+++ b/src/obsidian/settings-tab.ts
@@ -84,6 +84,20 @@ export default class SettingsTab extends PluginSettingTab {
 						await this.plugin.saveSettings();
 					})
 			);
+
+		new Setting(containerEl)
+			.setName("Export title and url")
+			.setDesc(
+				"If true, both the title and URL of the tab will be exported. If false, only the URL will be exported."
+			)
+			.addToggle((text) =>
+				text
+					.setValue(this.plugin.settings.exportTitleAndUrl)
+					.onChange(async (value) => {
+						this.plugin.settings.exportTitleAndUrl = value;
+						await this.plugin.saveSettings();
+					})
+			);
 	}
 
 	renderMultipleNoteSettings(containerEl: HTMLElement): void {
@@ -99,20 +113,6 @@ export default class SettingsTab extends PluginSettingTab {
 					.setValue(this.plugin.settings.urlFrontmatterKey)
 					.onChange(async (value) => {
 						this.plugin.settings.urlFrontmatterKey = value;
-						await this.plugin.saveSettings();
-					})
-			);
-
-		new Setting(containerEl)
-			.setName("Append website type")
-			.setDesc(
-				"Appends a website type to the end of the title. For example, if the website includes 'YouTube', (YouTube) will be appended to the end of the title."
-			)
-			.addToggle((text) =>
-				text
-					.setValue(this.plugin.settings.appendWebsiteType)
-					.onChange(async (value) => {
-						this.plugin.settings.appendWebsiteType = value;
 						await this.plugin.saveSettings();
 					})
 			);

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,8 +2,8 @@ export interface PluginSettings {
 	vaultSavePath: string;
 	fileName: string;
 	urlFrontmatterKey: string;
-	appendWebsiteType: boolean;
 	excludedLinks: string[];
+	exportTitleAndUrl: boolean;
 	localBrowserAppName: string;
 	remoteBrowserAppName: string;
 	adbPath: string;

--- a/src/utils/string-utils.ts
+++ b/src/utils/string-utils.ts
@@ -1,25 +1,3 @@
-export const toSentenceCase = (value: string) => {
-	// Split the text into sentences using a regular expression
-	const sentences = value.split(/(?<=[.!?])\s/);
-
-	// Convert each sentence to sentence case
-	return sentences.map(sentence => {
-		// Split the sentence into words
-		const words = sentence.split(' ');
-
-		// Convert each word to the correct case
-		const correctedWords = words.map((word, index) => {
-			if (word.toLowerCase() === 'i') {
-				return 'I'; // Always capitalize 'I'
-			}
-			return index === 0 ? word.charAt(0).toUpperCase() + word.slice(1).toLowerCase() : word.toLowerCase();
-		});
-
-		// Rejoin the words into a sentence
-		return correctedWords.join(' ');
-	}).join(' ');
-}
-
 export const decodeHtmlEntities = (value: string) => {
 	var textarea = document.createElement('textarea');
 	textarea.innerHTML = value;

--- a/src/utils/title-utils.ts
+++ b/src/utils/title-utils.ts
@@ -6,34 +6,6 @@ export const removeQuotations = (value: string) => {
 	return value;
 }
 
-export const removeTrailingPeriod = (value: string) => {
-	return value.replace(/\.$/, "");
-}
-
-/**
- * Removes website titles from the end of a string
- * @param value - The title to format
- */
-export const removeWebsiteTitles = (value: string) => {
-	console.log(value);
-	value = value.replace(/on X-/, "-");
-	value = value.replace(/YouTube$/, "");
-	value = value.replace(/Search X$/, "");
-	value = value.replace(/Wikipedia$/, "");
-	value = value.replace(/Amazon$/, "");
-	value = value.replace(/Medium$/, "");
-	value = value.replace(/GitHub$/, "");
-	value = value.replace(/Instagram$/, "");
-	value = value.replace(/Pintrest$/, "");
-	value = value.replace(/X$/, "");
-	value = value.trim();
-	return value;
-}
-
-export const removeTrailingHyphen = (value: string) => {
-	return value.replace(/-$/, "");
-}
-
 /**
  * Finds the longest string in a string that is separated by a hyphen space `- ` or space hyphen ` -`
  * @param value - The value to format
@@ -51,35 +23,9 @@ export const findLongestString = (value: string) => {
 	return title;
 }
 
-export const trimForObsidian = (value: string, websiteTitle: string, extension: string) => {
-	const MAX_LENGTH = 150;
-	return value.substring(0, MAX_LENGTH - websiteTitle.length - 1 - extension.length - 1);
-}
-
-export const getWebsiteTitle = (url: string) => {
-	if (url.includes("youtube.com")) {
-		return "YouTube";
-	} else if (url.includes("x.com") || (url.includes("twitter.com"))) {
-		return "X";
-	} else if (url.includes("instagram.com")) {
-		return "Instagram";
-	} else if (url.includes("pintrest.com")) {
-		return "Pintrest";
-	} else if (url.includes("github.com")) {
-		return "GitHub";
-	} else if (url.includes("medium.com")) {
-		return "Medium";
-	} else if (url.includes("wikipedia.com")) {
-		return "Wikipedia";
-	} else if (url.includes("amazon.com")) {
-		return "Amazon";
-	} else {
-		return "Website"
-	}
-}
-
-export const appendWebsiteTitle = (value: string, websiteTitle: string) => {
-	return `${value} (${websiteTitle})`;
+export const trimForFileSystem = (value: string, extension: string) => {
+	const MAX_LENGTH = 255;
+	return value.substring(0, MAX_LENGTH - extension.length).trim();
 }
 
 export const removeNotificationCount = (value: string) => {

--- a/src/utils/title-utils.ts
+++ b/src/utils/title-utils.ts
@@ -31,3 +31,7 @@ export const trimForFileSystem = (value: string, extension: string) => {
 export const removeNotificationCount = (value: string) => {
 	return value.replace(/^\(\d\)/, "").trim();
 }
+
+export const getEmptyTabTitle = () => {
+	return `Untitled tab ${crypto.randomUUID()}`;
+}


### PR DESCRIPTION
**Feature**
- filter excluded tabs on single note export
- add export title and url option for single note export

**Fix**
- handle empty tab title. This can happen when the browser hasn't loaded the webpage yet. This will now output "Untitled tab {ID}"
- simplify log messages
- don't export tabs with duplicate urls

**Refactor**
- simplify tab title to match what is displayed in the browser