### PR TITLE
feat: report actionable errors from the remote export

### DIFF
--- a/docs/export-flowchart.md
+++ b/docs/export-flowchart.md
@@ -1,3 +1,5 @@
+## Export (local)
+
 ```mermaid
 ---
 title: Export browser tabs command
@@ -16,3 +18,46 @@ flowchart TD
 
 	end
 ```
+
+## Export (remote)
+
+The remote export talks to a browser on a connected Android device over ADB and the
+Chrome DevTools Protocol. Each step is its own checked subprocess, so a failure can
+say which stage broke and what to do about it.
+
+```mermaid
+---
+title: Export browser tabs (remote) command
+---
+flowchart TD
+	Start --> V{"Validate ADB path<br/>(absolute, exists, executable)"}
+	V -- invalid --> Err[Show what to fix]
+	V -- ok --> D{"adb devices -l"}
+	D -- "none / unauthorized / offline / multiple" --> Err
+	D -- one device --> S["adb shell cat /proc/net/unix<br/>discover DevTools sockets"]
+	S -- unreadable --> Fallback[Fall back to chrome_devtools_remote]
+	S -- "none listening" --> Err
+	S -- "no match, several candidates" --> Err
+	Fallback --> F
+	S -- matched --> F["adb forward tcp:0<br/>adb picks a free port"]
+	F -- failed --> Err
+	F --> H["GET 127.0.0.1:port/json/list"]
+	H -- "refused / timeout / bad status / bad JSON" --> Cleanup
+	H --> P["Keep type=page targets with http(s) urls<br/>then deduplicate"]
+	P --> one
+	subgraph one[for each tab]
+	C{Check if excluded} --> D2{Check if url already in vault}
+	D2 --> E[Decode HTML entities]
+	E --> E2[Remove invalid characters for file system]
+	E2 --> G["Remove notification count '(1)'"]
+	G --> G2[Trim to 255 characters]
+	G2 --> I["Create file<br/>a name collision becomes a 'Tab conflict' file"]
+	end
+	one --> Summary["Summary: exported, skipped, renamed, failed"]
+	Summary --> Cleanup["adb forward --remove<br/>always runs"]
+	Err --> Done
+	Cleanup --> Done([Done])
+```
+
+A per-tab failure is counted and the export continues, so one bad tab cannot lose the
+rest of the run.

--- a/src/commands/export-remote-command.ts
+++ b/src/commands/export-remote-command.ts
@@ -1,4 +1,5 @@
 import { App, Command, Notice } from "obsidian";
+import { RemoteExportError, getErrorMessage } from "src/export/errors";
 import { exportRemoteTabs } from "src/export/remote-export";
 import { PluginSettings } from "src/types";
 import { formatForFileSystem } from "src/utils/file-system-utils";
@@ -10,7 +11,12 @@ import {
 	removeNotificationCount,
 	trimForFileSystem,
 } from "src/utils/title-utils";
-import { doesUrlExist } from "src/utils/vault";
+import { getFrontmatterUrl } from "src/utils/vault";
+
+/** Running two exports at once would let one tear down the other's port forward */
+let isExporting = false;
+
+const NOTICE_ERROR_DURATION_MS = 10_000;
 
 export const exportRemoteCommand = (
 	app: App,
@@ -23,6 +29,23 @@ export const exportRemoteCommand = (
 	};
 };
 
+/**
+ * Collects every URL already saved in the vault.
+ * Built once per export - checking each tab against every file would be quadratic
+ * and freeze the UI on a large vault.
+ * @param app - The Obsidian app object
+ */
+const getExistingUrls = (app: App): Set<string> => {
+	const urls = new Set<string>();
+	for (const file of app.vault.getMarkdownFiles()) {
+		const url = getFrontmatterUrl(app, file);
+		if (url !== undefined) {
+			urls.add(url);
+		}
+	}
+	return urls;
+};
+
 const callback = (app: App, settings: PluginSettings) => async () => {
 	const {
 		saveFolder,
@@ -31,46 +54,103 @@ const callback = (app: App, settings: PluginSettings) => async () => {
 		excludedLinks,
 		adbPath,
 	} = settings;
+
+	if (isExporting) {
+		new Notice("A remote export is already running.");
+		return;
+	}
+	isExporting = true;
+
 	try {
+		if (saveFolder === "") {
+			throw new RemoteExportError(
+				"MISSING_SAVE_FOLDER",
+				"No save folder specified. Please set one in the plugin settings."
+			);
+		}
+
+		new Notice("Exporting remote browser tabs...");
+
 		await createFolder(app, saveFolder);
 		const tabs = await exportRemoteTabs(remoteBrowserAppName, adbPath);
 		console.log(`Found ${tabs.length} remote browser tabs`);
 
+		if (tabs.length === 0) {
+			new Notice(`No open tabs found in ${remoteBrowserAppName}.`);
+			return;
+		}
+
+		const existingUrls = getExistingUrls(app);
+
 		let numExportedTabs = 0;
+		let numSkippedTabs = 0;
+		let numRenamedTabs = 0;
+		let numFailedTabs = 0;
 
 		for (const tab of tabs) {
 			const { title, url } = tab;
 
-			if (excludedLinks.find((link) => url.includes(link))) {
-				console.log(`URL is excluded: ${url}`);
-				continue;
+			try {
+				if (excludedLinks.find((link) => url.includes(link))) {
+					console.log(`URL is excluded: ${url}`);
+					numSkippedTabs++;
+					continue;
+				}
+
+				if (existingUrls.has(url)) {
+					console.log(`URL already exists in vault: ${url}`);
+					numSkippedTabs++;
+					continue;
+				}
+
+				const titlePipeline = pipeline(
+					decodeHtmlEntities,
+					formatForFileSystem,
+					removeNotificationCount
+				);
+				const formattedTitle = titlePipeline(title) as string;
+				const trimmedTitle = trimForFileSystem(formattedTitle, ".md");
+				const data = generateFrontmatter(urlFrontmatterKey, url);
+
+				const didUseGivenName = await createFileByParts(
+					app,
+					saveFolder,
+					trimmedTitle,
+					"md",
+					data
+				);
+				//A name collision falls back to a "Tab conflict" file, which the user
+				//would otherwise have no way of knowing about
+				if (!didUseGivenName) {
+					numRenamedTabs++;
+				}
+
+				existingUrls.add(url);
+				numExportedTabs++;
+			} catch (err) {
+				console.error(err);
+				numFailedTabs++;
 			}
-
-			if (doesUrlExist(app, url)) {
-				console.log(`URL already exists in vault: ${url}`);
-				continue;
-			}
-
-			const titlePipeline = pipeline(
-				decodeHtmlEntities,
-				formatForFileSystem,
-				removeNotificationCount
-			);
-			const formattedTitle = titlePipeline(title) as string;
-			const trimmedTitle = trimForFileSystem(formattedTitle, ".md");
-			const data = generateFrontmatter(urlFrontmatterKey, url);
-
-			await createFileByParts(app, saveFolder, trimmedTitle, "md", data);
-			numExportedTabs++;
 		}
-		new Notice(
-			`Exported ${numExportedTabs} remote browser tabs from ${remoteBrowserAppName}`
-		);
-		console.log(
-			`Exported ${numExportedTabs} remote browser tabs from ${remoteBrowserAppName}`
-		);
+
+		const details = [
+			numSkippedTabs > 0 ? `${numSkippedTabs} skipped` : null,
+			numRenamedTabs > 0 ? `${numRenamedTabs} renamed` : null,
+			numFailedTabs > 0 ? `${numFailedTabs} failed` : null,
+		].filter((detail) => detail !== null);
+
+		const message = `Export complete: ${numExportedTabs} tabs exported from ${remoteBrowserAppName}${
+			details.length > 0 ? `, ${details.join(", ")}` : ""
+		}`;
+		new Notice(message);
+		console.log(message);
 	} catch (err) {
 		console.error(err);
-		new Notice(`Error exporting browser tabs: ${err.message} `);
+		if (err instanceof RemoteExportError && err.detail !== undefined) {
+			console.error(err.detail);
+		}
+		new Notice(getErrorMessage(err), NOTICE_ERROR_DURATION_MS);
+	} finally {
+		isExporting = false;
 	}
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,1 +1,11 @@
 export const EXCLUDED_LINKS_VIEW = "excluded-links";
+
+/** `adb devices` has to start the adb daemon on a cold run, which is slow */
+export const ADB_DEVICES_TIMEOUT_MS = 15_000;
+export const ADB_SHELL_TIMEOUT_MS = 10_000;
+export const ADB_FORWARD_TIMEOUT_MS = 10_000;
+export const ADB_FORWARD_REMOVE_TIMEOUT_MS = 5_000;
+export const DEVTOOLS_TIMEOUT_MS = 5_000;
+
+/** The socket used when the device will not let us enumerate what is listening */
+export const FALLBACK_DEVTOOLS_SOCKET = "chrome_devtools_remote";

--- a/src/export/adb.ts
+++ b/src/export/adb.ts
@@ -1,0 +1,333 @@
+import { accessSync, constants, existsSync } from "fs";
+import { isAbsolute } from "path";
+import {
+	ADB_DEVICES_TIMEOUT_MS,
+	ADB_FORWARD_REMOVE_TIMEOUT_MS,
+	ADB_FORWARD_TIMEOUT_MS,
+	ADB_SHELL_TIMEOUT_MS,
+	FALLBACK_DEVTOOLS_SOCKET,
+} from "src/constants";
+import { CommandResult, firstLine, runCommand } from "src/utils/exec-utils";
+import { RemoteExportError } from "./errors";
+
+export interface AndroidDevice {
+	serial: string;
+	state: string;
+}
+
+/**
+ * Validates the configured ADB path without spawning anything.
+ * Obsidian launched from Finder does not inherit the login shell's PATH, which is
+ * why an absolute path is required here at all.
+ * @throws RemoteExportError if the path is unset, relative, missing or not executable
+ * @param adbPath - The absolute path to the ADB executable
+ */
+export const validateAdbPath = (adbPath: string): void => {
+	if (adbPath === "") {
+		throw new RemoteExportError(
+			"MISSING_ADB_PATH",
+			"No ADB path specified. Please set one in the plugin settings."
+		);
+	}
+
+	if (!isAbsolute(adbPath)) {
+		throw new RemoteExportError(
+			"ADB_PATH_NOT_ABSOLUTE",
+			"The ADB path must be absolute (e.g. /opt/homebrew/bin/adb). Obsidian does not use your terminal's PATH."
+		);
+	}
+
+	if (!existsSync(adbPath)) {
+		throw new RemoteExportError(
+			"ADB_NOT_FOUND",
+			`ADB was not found at "${adbPath}". Run "which adb" in your terminal and paste the full path into the plugin settings.`
+		);
+	}
+
+	try {
+		accessSync(adbPath, constants.X_OK);
+	} catch {
+		throw new RemoteExportError(
+			"ADB_NOT_EXECUTABLE",
+			`ADB at "${adbPath}" is not executable. Check the path in the plugin settings, or run "chmod +x ${adbPath}".`
+		);
+	}
+};
+
+/**
+ * Translates a failed adb invocation into an error whose message can be shown as-is.
+ * Note that stderr is only consulted once the exit code has already told us the
+ * command failed - adb writes daemon startup notices to stderr on successful runs.
+ * @param result - The result of the adb command
+ * @param adbPath - The absolute path to the ADB executable, quoted back to the user
+ * @param timeoutMs - The timeout that was applied, reported in seconds
+ */
+const toAdbError = (
+	result: CommandResult,
+	adbPath: string,
+	timeoutMs: number
+): RemoteExportError => {
+	if (result.timedOut) {
+		return new RemoteExportError(
+			"ADB_TIMEOUT",
+			`ADB did not respond within ${Math.round(
+				timeoutMs / 1000
+			)} seconds. Try running "${adbPath} kill-server" in your terminal, then try again.`,
+			result.stderr
+		);
+	}
+
+	if (result.spawnError !== null) {
+		return new RemoteExportError(
+			"ADB_NOT_EXECUTABLE",
+			`ADB at "${adbPath}" could not be run. Check the path in the plugin settings.`,
+			result.spawnError.message
+		);
+	}
+
+	const detail = firstLine(result.stderr);
+	return new RemoteExportError(
+		"ADB_FAILED",
+		`ADB failed: ${detail === "" ? "no output" : detail}`,
+		result.stderr
+	);
+};
+
+/**
+ * Parses the output of `adb devices -l`.
+ * @param stdout - The raw output of the command
+ */
+export const parseDeviceList = (stdout: string): AndroidDevice[] => {
+	return stdout
+		.split("\n")
+		.map((line) => line.trim())
+		.filter((line) => line !== "" && !line.startsWith("List of devices"))
+		//`adb devices -l` separates the serial from the state with whitespace
+		.map((line) => line.split(/\s+/))
+		.filter((parts) => parts.length >= 2)
+		.map((parts) => ({ serial: parts[0], state: parts[1] }));
+};
+
+/**
+ * Returns the serial of the single connected device.
+ * @throws RemoteExportError if there is not exactly one usable device
+ * @param adbPath - The absolute path to the ADB executable
+ */
+export const getConnectedDeviceSerial = async (
+	adbPath: string
+): Promise<string> => {
+	const result = await runCommand(adbPath, ["devices", "-l"], {
+		timeoutMs: ADB_DEVICES_TIMEOUT_MS,
+	});
+
+	if (result.code !== 0) {
+		throw toAdbError(result, adbPath, ADB_DEVICES_TIMEOUT_MS);
+	}
+
+	const devices = parseDeviceList(result.stdout);
+
+	if (devices.length === 0) {
+		throw new RemoteExportError(
+			"NO_DEVICES",
+			"No devices found. Connect your device over USB, enable USB debugging, and try again."
+		);
+	}
+
+	if (devices.length > 1) {
+		const serials = devices.map((device) => device.serial).join(", ");
+		throw new RemoteExportError(
+			"MULTIPLE_DEVICES",
+			`Multiple devices are connected (${serials}). Disconnect all but one and try again.`
+		);
+	}
+
+	const [device] = devices;
+
+	if (device.state === "unauthorized") {
+		throw new RemoteExportError(
+			"DEVICE_UNAUTHORIZED",
+			'Device is unauthorized. Unlock the device, tap "Allow USB debugging", then try again.'
+		);
+	}
+
+	if (device.state !== "device") {
+		throw new RemoteExportError(
+			"DEVICE_OFFLINE",
+			"Device is offline. Reconnect the USB cable or toggle USB debugging off and on, then try again."
+		);
+	}
+
+	return device.serial;
+};
+
+/**
+ * Extracts the DevTools socket names from the contents of /proc/net/unix.
+ * Abstract socket names are prefixed with an @ in that file.
+ * @param stdout - The contents of /proc/net/unix
+ */
+export const parseDevToolsSockets = (stdout: string): string[] => {
+	const matches = stdout.matchAll(/@([\w.-]*_devtools_remote[\w.-]*)/g);
+	const names = Array.from(matches, (match) => match[1]);
+	return Array.from(new Set(names));
+};
+
+/**
+ * Picks the socket belonging to the configured browser.
+ * The names are not guessed from a hardcoded table: they vary by browser build and
+ * version, and a wrong guess produces exactly the silent failure this is meant to fix.
+ * @param sockets - The socket names discovered on the device
+ * @param appName - The configured remote browser application name
+ */
+export const matchDevToolsSocket = (
+	sockets: string[],
+	appName: string
+): string | null => {
+	const normalized = appName.toLowerCase().replace(/[\s.]/g, "");
+	if (normalized === "") return null;
+
+	const match = sockets.find((socket) =>
+		socket.toLowerCase().includes(normalized)
+	);
+	if (match !== undefined) return match;
+
+	//A single browser is listening but it isn't named what the user typed. Embedded
+	//webviews are excluded because they are rarely what someone means to export.
+	const candidates = sockets.filter(
+		(socket) => !socket.startsWith("webview_")
+	);
+	if (candidates.length === 1) {
+		console.warn(
+			`No DevTools socket matched "${appName}". Falling back to the only one found: ${candidates[0]}`
+		);
+		return candidates[0];
+	}
+
+	return null;
+};
+
+/**
+ * Discovers which browser on the device is exposing a DevTools socket.
+ * This is the same mechanism Chrome's own "Discover USB devices" UI uses.
+ * @throws RemoteExportError if nothing is listening or nothing matches the app name
+ * @param adbPath - The absolute path to the ADB executable
+ * @param serial - The serial of the connected device
+ * @param appName - The configured remote browser application name
+ */
+export const findDevToolsSocket = async (
+	adbPath: string,
+	serial: string,
+	appName: string
+): Promise<string> => {
+	const result = await runCommand(
+		adbPath,
+		["-s", serial, "shell", "cat", "/proc/net/unix"],
+		{ timeoutMs: ADB_SHELL_TIMEOUT_MS }
+	);
+
+	//Some hardened builds refuse to read /proc/net/unix. Discovery must never be the
+	//reason a setup that works today stops working.
+	if (result.code !== 0) {
+		console.warn(
+			`Could not list sockets on the device, falling back to ${FALLBACK_DEVTOOLS_SOCKET}`,
+			result.stderr
+		);
+		return FALLBACK_DEVTOOLS_SOCKET;
+	}
+
+	const sockets = parseDevToolsSockets(result.stdout);
+	console.log(`Found DevTools sockets on the device: ${sockets.join(", ")}`);
+
+	if (sockets.length === 0) {
+		throw new RemoteExportError(
+			"NO_DEVTOOLS_SOCKETS",
+			`No debuggable browser found on the device. Make sure ${appName} is open on the device, then try again.`
+		);
+	}
+
+	const socket = matchDevToolsSocket(sockets, appName);
+	if (socket === null) {
+		throw new RemoteExportError(
+			"SOCKET_NAME_MISMATCH",
+			`No browser matching "${appName}" is running on the device. Found: ${sockets.join(
+				", "
+			)}. Update the remote browser application name in the plugin settings.`
+		);
+	}
+
+	return socket;
+};
+
+/**
+ * Opens a port forward to the device and returns the local port that adb allocated.
+ * Asking for tcp:0 lets adb pick a free port, so this can never collide with a
+ * desktop browser already listening on the usual debugging port.
+ *
+ * Note that adb resolves the remote socket lazily, so this succeeding does not prove
+ * the socket exists - that is what findDevToolsSocket is for.
+ * @throws RemoteExportError if the forward could not be opened
+ * @param adbPath - The absolute path to the ADB executable
+ * @param serial - The serial of the connected device
+ * @param socket - The name of the abstract socket to forward to
+ */
+export const openPortForward = async (
+	adbPath: string,
+	serial: string,
+	socket: string
+): Promise<number> => {
+	const result = await runCommand(
+		adbPath,
+		["-s", serial, "forward", "tcp:0", `localabstract:${socket}`],
+		{ timeoutMs: ADB_FORWARD_TIMEOUT_MS }
+	);
+
+	if (result.code !== 0) {
+		const detail = firstLine(result.stderr);
+		throw new RemoteExportError(
+			"FORWARD_FAILED",
+			`Could not open a connection to the device: ${
+				detail === "" ? "adb gave no reason" : detail
+			}`,
+			result.stderr
+		);
+	}
+
+	const port = Number.parseInt(result.stdout.trim(), 10);
+	if (!Number.isInteger(port) || port <= 0) {
+		throw new RemoteExportError(
+			"FORWARD_FAILED",
+			"Could not open a connection to the device: adb did not report a port.",
+			result.stdout
+		);
+	}
+
+	return port;
+};
+
+/**
+ * Tears down a port forward. Never throws - this runs in a finally block, where
+ * failing would mask the error that actually matters.
+ * @param adbPath - The absolute path to the ADB executable
+ * @param serial - The serial of the connected device
+ * @param port - The local port to stop forwarding
+ */
+export const closePortForward = async (
+	adbPath: string,
+	serial: string,
+	port: number
+): Promise<void> => {
+	try {
+		const result = await runCommand(
+			adbPath,
+			["-s", serial, "forward", "--remove", `tcp:${port}`],
+			{ timeoutMs: ADB_FORWARD_REMOVE_TIMEOUT_MS }
+		);
+		if (result.code !== 0) {
+			console.warn(
+				`Could not remove the port forward on tcp:${port}`,
+				result.stderr
+			);
+		}
+	} catch (err) {
+		console.warn(`Could not remove the port forward on tcp:${port}`, err);
+	}
+};

--- a/src/export/devtools.ts
+++ b/src/export/devtools.ts
@@ -1,0 +1,169 @@
+import { request } from "http";
+import { getEmptyTabTitle } from "src/utils/title-utils";
+import { RemoteExportError } from "./errors";
+import { BrowserTab } from "./types";
+import { filterDuplicateTabs } from "./utils";
+
+/**
+ * Fetches the DevTools target list over the adb port forward.
+ *
+ * 127.0.0.1 is used rather than localhost on purpose: localhost can resolve to ::1
+ * first, and adb only listens on IPv4, which fails in a way that is hard to diagnose.
+ * @throws RemoteExportError if the browser cannot be reached or does not answer with JSON
+ * @param port - The local port that adb forwarded
+ * @param timeoutMs - How long to wait for the browser to answer
+ * @param appName - The configured remote browser application name, used in messages
+ */
+export const fetchDevToolsTargets = (
+	port: number,
+	timeoutMs: number,
+	appName: string
+): Promise<unknown> => {
+	return new Promise<unknown>((resolve, reject) => {
+		let isSettled = false;
+		let timer: ReturnType<typeof setTimeout> | null = null;
+
+		const settle = (err: RemoteExportError | null, value?: unknown) => {
+			if (isSettled) return;
+			isSettled = true;
+			if (timer !== null) clearTimeout(timer);
+			if (err !== null) {
+				reject(err);
+			} else {
+				resolve(value);
+			}
+		};
+
+		const connectionRefused = (detail?: string) =>
+			new RemoteExportError(
+				"DEVTOOLS_CONNECTION_REFUSED",
+				`${appName} is not accepting debug connections. Make sure it is open on the device, then try again.`,
+				detail
+			);
+
+		const req = request(
+			{
+				host: "127.0.0.1",
+				port,
+				path: "/json/list",
+				method: "GET",
+			},
+			(res) => {
+				const status = res.statusCode ?? 0;
+				const chunks: Buffer[] = [];
+
+				res.on("data", (chunk: Buffer) => chunks.push(chunk));
+				res.on("end", () => {
+					const body = Buffer.concat(chunks).toString("utf8");
+
+					if (status < 200 || status >= 300) {
+						settle(
+							new RemoteExportError(
+								"DEVTOOLS_BAD_STATUS",
+								`The device returned HTTP ${status} when listing tabs. See the developer console for details.`,
+								body
+							)
+						);
+						return;
+					}
+
+					if (body.trim() === "") {
+						settle(connectionRefused());
+						return;
+					}
+
+					try {
+						settle(null, JSON.parse(body));
+					} catch {
+						settle(
+							new RemoteExportError(
+								"DEVTOOLS_INVALID_RESPONSE",
+								`Could not read the tab list from ${appName}. See the developer console for details.`,
+								body.slice(0, 200)
+							)
+						);
+					}
+				});
+			}
+		);
+
+		//An own timer rather than the socket timeout option: a browser that accepts the
+		//connection and then never answers must not be able to hang the export, and the
+		//socket timeout does not reliably cover that case.
+		timer = setTimeout(() => {
+			settle(
+				new RemoteExportError(
+					"DEVTOOLS_TIMEOUT",
+					`${appName} did not respond within ${Math.round(
+						timeoutMs / 1000
+					)} seconds. Try again.`
+				)
+			);
+			req.destroy();
+		}, timeoutMs);
+
+		req.on("error", (err) => settle(connectionRefused(err.message)));
+
+		req.end();
+	});
+};
+
+const isPageUrl = (url: string): boolean => {
+	//Excludes chrome://, chrome-native://, devtools:// and about:blank
+	return url.startsWith("http://") || url.startsWith("https://");
+};
+
+/**
+ * Turns a DevTools target list into browser tabs, discarding anything that is not a
+ * real page. Nothing in the payload is trusted: it comes from another device.
+ * @throws RemoteExportError if the payload is not a list of targets
+ * @param payload - The parsed JSON body of /json/list
+ */
+export const parseDevToolsTargets = (payload: unknown): BrowserTab[] => {
+	if (!Array.isArray(payload)) {
+		throw new RemoteExportError(
+			"DEVTOOLS_INVALID_RESPONSE",
+			"Could not read the tab list from the device. See the developer console for details.",
+			JSON.stringify(payload).slice(0, 200)
+		);
+	}
+
+	let numSkipped = 0;
+
+	const tabs: BrowserTab[] = [];
+	for (const entry of payload) {
+		if (typeof entry !== "object" || entry === null) {
+			numSkipped++;
+			continue;
+		}
+
+		const { url, title, type } = entry as {
+			url?: unknown;
+			title?: unknown;
+			type?: unknown;
+		};
+
+		//Service workers, background pages and iframes are targets too, but they
+		//are not tabs anyone wants a note for
+		if (typeof type === "string" && type !== "page") {
+			numSkipped++;
+			continue;
+		}
+
+		if (typeof url !== "string" || !isPageUrl(url)) {
+			numSkipped++;
+			continue;
+		}
+
+		//The title is empty while a tab is still loading
+		const hasTitle = typeof title === "string" && title.trim() !== "";
+		tabs.push({ url, title: hasTitle ? title : getEmptyTabTitle() });
+	}
+
+	if (numSkipped > 0) {
+		console.log(`Skipped ${numSkipped} DevTools targets that were not pages`);
+	}
+
+	//Deduplicate after filtering so the count is not inflated by discarded targets
+	return filterDuplicateTabs(tabs);
+};

--- a/src/export/errors.ts
+++ b/src/export/errors.ts
@@ -1,0 +1,57 @@
+export type RemoteExportErrorCode =
+	| "MISSING_ADB_PATH"
+	| "ADB_PATH_NOT_ABSOLUTE"
+	| "ADB_NOT_FOUND"
+	| "ADB_NOT_EXECUTABLE"
+	| "ADB_TIMEOUT"
+	| "ADB_FAILED"
+	| "NO_DEVICES"
+	| "DEVICE_UNAUTHORIZED"
+	| "DEVICE_OFFLINE"
+	| "MULTIPLE_DEVICES"
+	| "MISSING_APP_NAME"
+	| "MISSING_SAVE_FOLDER"
+	| "NO_DEVTOOLS_SOCKETS"
+	| "SOCKET_NAME_MISMATCH"
+	| "FORWARD_FAILED"
+	| "DEVTOOLS_CONNECTION_REFUSED"
+	| "DEVTOOLS_TIMEOUT"
+	| "DEVTOOLS_BAD_STATUS"
+	| "DEVTOOLS_INVALID_RESPONSE"
+	| "EXPORT_ALREADY_RUNNING";
+
+/**
+ * An error with a message that is ready to be shown in a Notice as-is.
+ * Anything too long or too technical for a toast belongs in `detail`, which is
+ * only ever written to the console.
+ */
+export class RemoteExportError extends Error {
+	code: RemoteExportErrorCode;
+	detail?: string;
+
+	constructor(
+		code: RemoteExportErrorCode,
+		message: string,
+		detail?: string
+	) {
+		super(message);
+		this.name = "RemoteExportError";
+		this.code = code;
+		this.detail = detail;
+	}
+}
+
+/**
+ * Normalizes an unknown catch binding into a message that can be shown to the user.
+ * A thrown non-Error would otherwise render as "undefined".
+ * @param err - The caught value
+ */
+export const getErrorMessage = (err: unknown): string => {
+	if (err instanceof RemoteExportError) {
+		return err.message;
+	}
+	if (err instanceof Error) {
+		return `Error exporting browser tabs: ${err.message}`;
+	}
+	return `Error exporting browser tabs: ${String(err)}`;
+};

--- a/src/export/remote-export.ts
+++ b/src/export/remote-export.ts
@@ -1,67 +1,54 @@
-import { exec as execCallback } from "child_process";
-import { promisify } from "util";
+import { DEVTOOLS_TIMEOUT_MS } from "src/constants";
+import {
+	closePortForward,
+	findDevToolsSocket,
+	getConnectedDeviceSerial,
+	openPortForward,
+	validateAdbPath,
+} from "./adb";
+import { fetchDevToolsTargets, parseDevToolsTargets } from "./devtools";
+import { RemoteExportError } from "./errors";
 import { BrowserTab } from "./types";
-import { getEmptyTabTitle } from "src/utils/title-utils";
-import { filterDuplicateTabs } from "./utils";
 
-const exec = promisify(execCallback);
-
-export const exportRemoteTabs = async (browserApplicationName: string, adbPath: string): Promise<BrowserTab[]> => {
+/**
+ * Reads the open tabs from a browser running on a connected Android device.
+ *
+ * Each step runs as its own checked subprocess so that a failure can say which stage
+ * broke and what the user should do about it.
+ * @throws RemoteExportError with a message suitable for showing to the user
+ * @param browserApplicationName - The name of the browser running on the device
+ * @param adbPath - The absolute path to the ADB executable
+ */
+export const exportRemoteTabs = async (
+	browserApplicationName: string,
+	adbPath: string
+): Promise<BrowserTab[]> => {
 	if (browserApplicationName === "") {
-		throw new Error(
+		throw new RemoteExportError(
+			"MISSING_APP_NAME",
 			"No remote browser application name specified. Please set one in the plugin settings."
 		);
 	}
 
-	if (adbPath === "") {
-		throw new Error(
-			"No ADB path specified. Please set one in the plugin settings."
-		);
-	}
+	validateAdbPath(adbPath);
 
-	//forwarding will output 9222 so we need to redirect that to /dev/null
-	let command = `
-		if ! command -v "${adbPath}" &> /dev/null
-		then
-			echo "${adbPath} could not be found, please install it and run this script again."
-			exit
-		fi
+	const serial = await getConnectedDeviceSerial(adbPath);
+	const socket = await findDevToolsSocket(
+		adbPath,
+		serial,
+		browserApplicationName
+	);
+	const port = await openPortForward(adbPath, serial, socket);
 
-		${adbPath} forward tcp:9222 localabstract:chrome_devtools_remote >/dev/null
-		curl -s http://localhost:9222/json/list
-		${adbPath} forward --remove tcp:9222
-	`;
-
-
+	//Opened after the forward exists, so cleanup only runs for a forward we created
 	try {
-		const MAX_BUFFER_SIZE = 1024 * 1024 * 10;
-		const { stdout, stderr } = await exec(command, { maxBuffer: MAX_BUFFER_SIZE });
-		if (stderr) {
-			throw new Error(stderr);
-		}
-
-		const arr = JSON.parse(stdout);
-		const tabs: BrowserTab[] = arr.map((entry: unknown) => {
-			const { url, title: originalTitle } = entry as {
-				title: string, url: string
-			}
-
-			let title = originalTitle;
-			//It's possible that the title is empty if the tab has not loaded yet
-			if (title.trim() === "")
-				title = getEmptyTabTitle();
-			return {
-				title,
-				url
-			}
-		});
-		const filteredTabs = filterDuplicateTabs(tabs);
-		return filteredTabs;
-	} catch (err: unknown) {
-		const error = err as Error;
-		if (error.message.includes("no devices/emulators found")) {
-			throw new Error("No devices found. Please connect a device and try again.");
-		}
-		throw err;
+		const payload = await fetchDevToolsTargets(
+			port,
+			DEVTOOLS_TIMEOUT_MS,
+			browserApplicationName
+		);
+		return parseDevToolsTargets(payload);
+	} finally {
+		await closePortForward(adbPath, serial, port);
 	}
-}
+};

--- a/src/obsidian/settings-tab.ts
+++ b/src/obsidian/settings-tab.ts
@@ -1,4 +1,10 @@
-import { App, PluginSettingTab, Setting } from "obsidian";
+import { App, Notice, PluginSettingTab, Setting } from "obsidian";
+import {
+	findDevToolsSocket,
+	getConnectedDeviceSerial,
+	validateAdbPath,
+} from "src/export/adb";
+import { getErrorMessage } from "src/export/errors";
 import ExportBrowserTabs from "../main";
 
 export default class SettingsTab extends PluginSettingTab {
@@ -66,7 +72,7 @@ export default class SettingsTab extends PluginSettingTab {
 		new Setting(containerEl)
 			.setName("ADB path")
 			.setDesc(
-				"The absolute path to the ADB executable on your machine. This can be found by running 'which adb' in your terminal."
+				"The absolute path to the ADB executable on your machine. Find it by running 'which adb' in your terminal. It must be absolute, because Obsidian does not use your terminal's PATH."
 			)
 			.addText((text) =>
 				text
@@ -80,7 +86,7 @@ export default class SettingsTab extends PluginSettingTab {
 		new Setting(containerEl)
 			.setName("Remote browser application name")
 			.setDesc(
-				"The name of the remote browser application to export tabs from. e.g. brave or chrome"
+				"The name of the remote browser application to export tabs from. e.g. brave or chrome. This is matched against the debugging sockets found on the device."
 			)
 			.addText((text) =>
 				text
@@ -90,5 +96,50 @@ export default class SettingsTab extends PluginSettingTab {
 						await this.plugin.saveSettings();
 					})
 			);
+
+		new Setting(containerEl)
+			.setName("Test connection")
+			.setDesc(
+				"Check that ADB can reach your device and find the browser, without exporting anything."
+			)
+			.addButton((button) =>
+				button.setButtonText("Test").onClick(async () => {
+					button.setDisabled(true);
+					button.setButtonText("Testing...");
+					try {
+						await this.testConnection();
+					} finally {
+						button.setDisabled(false);
+						button.setButtonText("Test");
+					}
+				})
+			);
+	}
+
+	/**
+	 * Runs the connection steps of a remote export and reports where it got to.
+	 * This exists so that a failing export can be diagnosed from the settings, rather
+	 * than only ever being reported as an export that found nothing.
+	 */
+	async testConnection(): Promise<void> {
+		const { adbPath, remoteBrowserAppName } = this.plugin.settings;
+		try {
+			if (remoteBrowserAppName === "") {
+				throw new Error(
+					"No remote browser application name specified. Please set one above."
+				);
+			}
+			validateAdbPath(adbPath);
+			const serial = await getConnectedDeviceSerial(adbPath);
+			const socket = await findDevToolsSocket(
+				adbPath,
+				serial,
+				remoteBrowserAppName
+			);
+			new Notice(`Connected to ${serial}, found ${socket}`, 10_000);
+		} catch (err) {
+			console.error(err);
+			new Notice(getErrorMessage(err), 10_000);
+		}
 	}
 }

--- a/src/utils/exec-utils.ts
+++ b/src/utils/exec-utils.ts
@@ -1,0 +1,95 @@
+import { execFile as execFileCallback } from "child_process";
+
+export interface CommandResult {
+	stdout: string;
+	stderr: string;
+	/** The exit code, or null when the process was killed by a signal or never spawned */
+	code: number | null;
+	timedOut: boolean;
+	/** Set when the process could not be spawned (ENOENT, EACCES) or its output overflowed */
+	spawnError: Error | null;
+}
+
+interface RunCommandOptions {
+	timeoutMs?: number;
+	maxBuffer?: number;
+}
+
+const DEFAULT_MAX_BUFFER = 1024 * 1024;
+
+/**
+ * Runs an executable directly, without a shell. Arguments are passed as an array, so
+ * paths containing spaces or quotes need no escaping.
+ *
+ * This never rejects. The same exit code means different things to different callers,
+ * so the decision of what counts as a failure is left to them.
+ * @param file - The absolute path to the executable
+ * @param args - The arguments to pass to the executable
+ * @param options - The timeout and max buffer size
+ */
+export const runCommand = async (
+	file: string,
+	args: string[],
+	options: RunCommandOptions = {}
+): Promise<CommandResult> => {
+	const { timeoutMs, maxBuffer = DEFAULT_MAX_BUFFER } = options;
+
+	return new Promise<CommandResult>((resolve) => {
+		execFileCallback(
+			file,
+			args,
+			{
+				timeout: timeoutMs,
+				//adb can ignore SIGTERM while it is starting its daemon
+				killSignal: "SIGKILL",
+				maxBuffer,
+			},
+			(err, stdout, stderr) => {
+				if (err === null) {
+					resolve({
+						stdout,
+						stderr,
+						code: 0,
+						timedOut: false,
+						spawnError: null,
+					});
+					return;
+				}
+
+				const { killed, signal, code } = err as Error & {
+					killed?: boolean;
+					signal?: string | null;
+					code?: number | string;
+				};
+
+				//A timeout kill and a maxBuffer overflow both surface as a killed process
+				const timedOut = killed === true || signal === "SIGKILL";
+				const isSpawnFailure =
+					code === "ENOENT" ||
+					code === "EACCES" ||
+					code === "ERR_CHILD_PROCESS_STDIO_MAXBUFFER";
+
+				resolve({
+					stdout,
+					stderr,
+					code: typeof code === "number" ? code : null,
+					timedOut: timedOut && !isSpawnFailure,
+					spawnError: isSpawnFailure ? err : null,
+				});
+			}
+		);
+	});
+};
+
+/**
+ * Returns the first non-empty line of a command's output, for use in a Notice.
+ * Full output belongs in the console, not in a toast.
+ * @param value - The output to take the first line of
+ */
+export const firstLine = (value: string): string => {
+	const line = value
+		.split("\n")
+		.map((it) => it.trim())
+		.find((it) => it !== "");
+	return line ?? "";
+};


### PR DESCRIPTION
The remote export ran as a single shell script (a `command -v` guard, `adb forward`, `curl`, `adb forward --remove`) and parsed its stdout as JSON. Only the last command's exit code reached exec, so nearly every real failure surfaced as "Unexpected end of JSON input", and a rejection put the whole script into the Notice. Exactly one case was handled, by substring match.

Each stage is now its own checked subprocess with its own timeout, and every failure maps to one sentence saying what to do about it.

- Run adb through execFile with an argv array instead of a shell, so paths with spaces work and the bashism in the guard is gone
- Let the exit code decide success. adb writes daemon startup notices to stderr on runs that succeed, which used to fail the export
- Validate the ADB path with fs rather than a `command -v` guard that echoed its error to stdout and exited 0
- Separate no device, unauthorized, offline and multiple devices
- Discover the DevTools socket from /proc/net/unix rather than assuming chrome_devtools_remote, which makes the remote browser name setting mean something for the first time. Falls back when the device won't list them
- Let adb allocate the port with tcp:0, so the export can't collide with a browser already listening on 9222
- Always remove the port forward, including when a stage throws
- Replace curl with node http on 127.0.0.1, for a real status code and a real timeout. localhost can resolve to ::1, which adb does not listen on
- Keep only page targets with http(s) urls, so service workers, iframes and about:blank stop becoming notes
- Isolate each tab, and report exported, skipped, renamed and failed. A single bad tab no longer loses the rest of the run
- Look up existing urls once instead of walking every note per tab
- Add a Test connection button to the settings, so a failing export can be diagnosed without running one