### PR TITLE
feat: name colliding tabs "(Duplicate)" instead of "Tab conflict"

### DIFF
--- a/docs/export-flowchart.md
+++ b/docs/export-flowchart.md
@@ -14,9 +14,10 @@ flowchart TD
 	E --> F["Remove notification count '(1)'"]
 	F --> G[Trim to 255 characters]
 	G --> H[Get frontmatter for file]
-	H --> I[Create file with frontmatter data]
+	H --> I["Create file with frontmatter data<br/>a name collision becomes '&lt;title&gt; (Duplicate N)'"]
 
 	end
+	one --> Summary["Summary: exported, renamed, failed"]
 ```
 
 ## Export (remote)
@@ -51,7 +52,7 @@ flowchart TD
 	E --> E2[Remove invalid characters for file system]
 	E2 --> G["Remove notification count '(1)'"]
 	G --> G2[Trim to 255 characters]
-	G2 --> I["Create file<br/>a name collision becomes a 'Tab conflict' file"]
+	G2 --> I["Create file<br/>a name collision becomes '&lt;title&gt; (Duplicate N)'"]
 	end
 	one --> Summary["Summary: exported, skipped, renamed, failed"]
 	Summary --> Cleanup["adb forward --remove<br/>always runs"]

--- a/src/commands/export-command.ts
+++ b/src/commands/export-command.ts
@@ -2,7 +2,7 @@ import { App, Command, Notice } from "obsidian";
 import { exportLocalTabs } from "src/export/local-export";
 import { PluginSettings } from "src/types";
 import { formatForFileSystem } from "src/utils/file-system-utils";
-import { createFile, createFolder } from "src/utils/file-utils";
+import { createFileWithUniqueName, createFolder } from "src/utils/file-utils";
 import { generateFrontmatter } from "src/utils/frontmatter-utils";
 import { pipeline } from "src/utils/pipeline";
 import { removeQueryParams } from "src/utils/string-utils";
@@ -30,6 +30,7 @@ const callback = (app: App, settings: PluginSettings) => async () => {
 		console.log(`Found ${tabs.length} browser tabs`);
 
 		let numExportedTabs = 0;
+		let numRenamedTabs = 0;
 		let numFailedTabs = 0;
 
 		for (const tab of tabs) {
@@ -55,20 +56,36 @@ const callback = (app: App, settings: PluginSettings) => async () => {
 				const formattedTitle = titlePipeline(title) as string;
 				const trimmedTitle = trimForFileSystem(formattedTitle, ".md");
 
-				const fileName = `${trimmedTitle}.md`;
-				const filePath = `${saveFolder}/${fileName}`;
 				const data = generateFrontmatter(urlProperty, url);
 
-				await createFile(app, filePath, data);
+				const createdName = await createFileWithUniqueName(
+					app,
+					saveFolder,
+					trimmedTitle,
+					"md",
+					data
+				);
+				//A name collision appends "(Duplicate)", which the user would
+				//otherwise have no way of knowing about
+				if (createdName !== trimmedTitle) {
+					numRenamedTabs++;
+				}
+
 				numExportedTabs++;
 			} catch (err) {
 				console.error(err);
 				numFailedTabs++;
 			}
 		}
+
+		const details = [
+			numRenamedTabs > 0 ? `${numRenamedTabs} renamed` : null,
+			numFailedTabs > 0 ? `${numFailedTabs} failed` : null,
+		].filter((detail) => detail !== null);
+
 		new Notice(
 			`Export complete: ${numExportedTabs} tabs exported from ${localBrowserAppName}${
-				numFailedTabs > 0 ? `, ${numFailedTabs} failed` : ""
+				details.length > 0 ? `, ${details.join(", ")}` : ""
 			}`
 		);
 	} catch (err) {

--- a/src/commands/export-remote-command.ts
+++ b/src/commands/export-remote-command.ts
@@ -3,7 +3,7 @@ import { RemoteExportError, getErrorMessage } from "src/export/errors";
 import { exportRemoteTabs } from "src/export/remote-export";
 import { PluginSettings } from "src/types";
 import { formatForFileSystem } from "src/utils/file-system-utils";
-import { createFileByParts, createFolder } from "src/utils/file-utils";
+import { createFileWithUniqueName, createFolder } from "src/utils/file-utils";
 import { generateFrontmatter } from "src/utils/frontmatter-utils";
 import { pipeline } from "src/utils/pipeline";
 import { decodeHtmlEntities } from "src/utils/string-utils";
@@ -112,16 +112,16 @@ const callback = (app: App, settings: PluginSettings) => async () => {
 				const trimmedTitle = trimForFileSystem(formattedTitle, ".md");
 				const data = generateFrontmatter(urlFrontmatterKey, url);
 
-				const didUseGivenName = await createFileByParts(
+				const createdName = await createFileWithUniqueName(
 					app,
 					saveFolder,
 					trimmedTitle,
 					"md",
 					data
 				);
-				//A name collision falls back to a "Tab conflict" file, which the user
-				//would otherwise have no way of knowing about
-				if (!didUseGivenName) {
+				//A name collision appends "(Duplicate)", which the user would
+				//otherwise have no way of knowing about
+				if (createdName !== trimmedTitle) {
 					numRenamedTabs++;
 				}
 

--- a/src/utils/file-utils.ts
+++ b/src/utils/file-utils.ts
@@ -1,4 +1,8 @@
-import { App, Notice, normalizePath } from "obsidian";
+import { App, normalizePath } from "obsidian";
+import { withDuplicateSuffix } from "src/utils/title-utils";
+
+/** Guards against an unbounded loop if `create` keeps reporting a collision */
+const MAX_DUPLICATE_ATTEMPTS = 100;
 
 /**
  * Creates a folder if it doesn't already exist
@@ -18,58 +22,36 @@ export const createFolder = async (app: App, folderPath: string) => {
 }
 
 /**
- * Creates a file. The path will be normalized.
+ * Creates a file, falling back to "<name> (Duplicate)", "<name> (Duplicate 2)", ...
+ * when the name is already taken. The path will be normalized.
+ * @throws If the file cannot be created for any reason other than a name collision
  * @param app - The Obsidian app object
- * @param filePath - The path to the file to create
+ * @param savePath - The folder to create the file in
+ * @param fileName - The desired file name, without an extension
+ * @param extension - The file extension, without a leading dot
  * @param data - The data to write to the file
+ * @returns The file name that was actually used, so the caller can report renames
  */
-export const createFile = async (
-	app: App,
-	filePath: string,
-	data: string
-) => {
-	try {
-		const normalizedFilePath = normalizePath(filePath);
-		await app.vault.create(normalizedFilePath, data);
-	} catch (err) {
-		if (err.message.includes("already exists")) {
-			throw new Error(`File already exists in vault: ${filePath}`);
-		}
-		throw err;
-	}
-}
-
-/**
- * Creates a file. The path will be normalized.
- * @param app - The Obsidian app object
- * @param filePath - The path to the file to create
- * @param data - The data to write to the file
- */
-export const createFileByParts = async (
+export const createFileWithUniqueName = async (
 	app: App,
 	savePath: string,
 	fileName: string,
 	extension: string,
 	data: string
-) => {
-	const filePath = `${savePath}/${fileName}.${extension}`;
-	try {
-		const normalizedFilePath = normalizePath(filePath);
-		await app.vault.create(normalizedFilePath, data);
-		return true;
-	} catch (err) {
-		if (err.message.includes("already exists")) {
-			// console.log("File already exists in vault:", filePath);
-			const newFilePath = `${savePath}/Tab conflict ${crypto.randomUUID()}.${extension}`;
-			try {
-				await createFile(app, newFilePath, data);
-			} catch (err) {
-				console.error(err);
-				new Notice(`Error creating file: ${err.message}`);
+): Promise<string> => {
+	for (let attempt = 0; attempt <= MAX_DUPLICATE_ATTEMPTS; attempt++) {
+		const name = withDuplicateSuffix(fileName, attempt, extension);
+		try {
+			const filePath = normalizePath(`${savePath}/${name}.${extension}`);
+			await app.vault.create(filePath, data);
+			return name;
+		} catch (err) {
+			if (!err.message.includes("already exists")) {
+				throw err;
 			}
-			return false;
 		}
-		throw err;
 	}
+	throw new Error(
+		`Could not find an available name for: ${fileName}.${extension}`
+	);
 }
-

--- a/src/utils/title-utils.ts
+++ b/src/utils/title-utils.ts
@@ -10,3 +10,22 @@ export const removeNotificationCount = (value: string) => {
 export const getEmptyTabTitle = () => {
 	return `Untitled tab ${crypto.randomUUID()}`;
 };
+
+/**
+ * Names the nth attempt at a file: "Title", "Title (Duplicate)", "Title (Duplicate 2)", ...
+ * The title is trimmed so the suffix and extension still fit the file system limit.
+ * @param title - The tab title, already formatted for the file system
+ * @param attempt - 0 for the original name, then one higher per collision
+ * @param extension - The file extension, without a leading dot
+ */
+export const withDuplicateSuffix = (
+	title: string,
+	attempt: number,
+	extension: string
+) => {
+	if (attempt === 0) {
+		return trimForFileSystem(title, `.${extension}`);
+	}
+	const suffix = attempt === 1 ? " (Duplicate)" : ` (Duplicate ${attempt})`;
+	return trimForFileSystem(title, `${suffix}.${extension}`) + suffix;
+};


### PR DESCRIPTION
## Summary

A name collision in the save folder used to discard the tab title entirely and write `Tab conflict <uuid>.md`, leaving a note whose name said nothing about what it held. It now keeps the title and disambiguates the way a file manager does:

```
My Tab Title.md
My Tab Title (Duplicate).md
My Tab Title (Duplicate 2).md
My Tab Title (Duplicate 3).md
```

The local export shared none of this — it created files directly, so a collision threw `File already exists in vault: …`, the tab was counted as failed, and nothing was written. Both commands now go through one helper and behave identically.

## Changes

- **`src/utils/title-utils.ts`** — new `withDuplicateSuffix(title, attempt, extension)`. Attempt 0 is the plain name; after that the suffix is appended. It reuses the existing `trimForFileSystem`, passing the suffix plus extension as the reserved tail, so a long title is shortened to make room rather than pushing the name past the 255-character limit.
- **`src/utils/file-utils.ts`** — `createFileByParts` and `createFile` are replaced by a single `createFileWithUniqueName`, which retries with the next duplicate name on each `"already exists"` error (capped at 100 attempts) and returns the name it actually used so the caller can count renames. Errors now propagate instead of being swallowed into a `Notice` — previously the fallback path logged, showed a notice, and still counted the tab as exported.
- **`src/commands/export-remote-command.ts`** — uses the new helper; `numRenamedTabs` increments on a name comparison rather than a boolean.
- **`src/commands/export-command.ts`** — uses the new helper, and adds a `renamed` count to the local summary notice using the same `details` pattern as the remote command.
- **`docs/export-flowchart.md`** — both flowcharts describe the new naming; the local one gained the summary node it was missing.

## Testing

`npm run build` (tsc + esbuild) passes.

The naming logic was checked standalone: names come out as `(Duplicate)` / `(Duplicate 2)` / `(Duplicate 3)`, a 300-character title still produces a 255-character file name ending in ` (Duplicate 12).md`, and a title with trailing whitespace does not produce a double space before the suffix.

Not yet exercised inside Obsidian. Manual pass worth doing before merge: create `<save folder>/Example.md` by hand, open a tab titled `Example`, run **Export**, and confirm `Example (Duplicate).md` plus a `1 renamed` notice. Strip the frontmatter `url` from the existing note first, or the URL dedup will skip the tab before it reaches the naming code.

## Out of scope

Two adjacent issues turned up while working on this and are left for follow-ups:

- `getFrontmatterUrl` (`src/utils/vault.ts`) hardcodes the `url` key while writes use the configurable `urlProperty` setting. A custom property silently breaks URL dedup, which is the main *source* of these collisions.
- `file-system-utils.trimForFileSystem` is dead code, shadowed by the `title-utils` one that both commands actually import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016XgJViiCKgDQzWkp6S5xvW
